### PR TITLE
demaion/itkotbwrapperconfig

### DIFF
--- a/utils/WrapperTemplates/LUMASSWrapperProfileTemplate.lwp
+++ b/utils/WrapperTemplates/LUMASSWrapperProfileTemplate.lwp
@@ -10,7 +10,7 @@ WrapperClassName            = NMScriptableKernelFilter2Wrapper
 ComponentName               = ImageBufferWriter
 
 # indicates whether this processing component is a SINK or not;
-# Sink components are executable and can from the 'bottom end'
+# Sink components are executable and can form the 'bottom end'
 # of a processing pipeline
 ComponentIsSink             = 1
 

--- a/utils/WrapperTemplates/makeWrapperConfigFile.py
+++ b/utils/WrapperTemplates/makeWrapperConfigFile.py
@@ -35,7 +35,9 @@ if __name__ == "__main__":
         "--componentName",
         type=str,
         help="an optional separate name for the component when it's displayed",
-        default=None,
+    )
+    parser.add_argument(
+        "--forwardInputUserIDs", type=str, help="optional function name"
     )
     parser.add_argument(
         "--componentIsSink",
@@ -70,6 +72,10 @@ if __name__ == "__main__":
         config["FilterClassFileName"] = extractor.extractFilterClassFileName(
             args.inputHeaderFile
         )
+
+        # Record function to forward user input IDs if given
+        if args.forwardInputUserIDs:
+            config["ForwardInputUserIDs"] = args.forwardInputUserIDs
 
         # Whether the component is a sink or a source/(source, sink) combination
         # needs to come from the command line
@@ -171,7 +177,6 @@ if __name__ == "__main__":
                         # TODO: extract InputTypeFunc entry from function signature
                         pass
 
-            # TODO: unclear how to ForwardInputUserIDs
             # TODO: unclear how to decide what should be captured as a Property (and how to detect it)
 
     # Sanity check: dictionary contents need to meet a few minimum requirements

--- a/utils/WrapperTemplates/makeWrapperConfigFile.py
+++ b/utils/WrapperTemplates/makeWrapperConfigFile.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+
+from sys import stderr
+
+import argparse as ap
+
+from pythonutils.extractor import Extractor
+from pythonutils.distiller import Distiller
+
+# Author name - use script name as specified to argument parser
+SCRIPT_NAME = "makeWrapperConfigFile"
+
+# Tuple of C/C++ access specifiers
+ACCESS_SPECIFIERS = ("public", "protected", "private")
+
+if __name__ == "__main__":
+    # Argument parser for command line arguments
+    parser = ap.ArgumentParser(
+        prog=SCRIPT_NAME,
+        description="Parses wrapper information out of a C++ header file for ITK / OTB filters and stores it in a config file for further processing",
+    )
+
+    # Define arguments accepted by parser
+    parser.add_argument(
+        "inputHeaderFile",
+        type=str,
+        help="the path to the input C++ header file (supports .h header files only)",
+    )
+    parser.add_argument(
+        "outputConfigFile",
+        type=str,
+        help="the path to the output config file (currently produces a .lwp file)",
+    )
+
+    # Parse the command line arguments
+    args = parser.parse_args()
+
+    # Sanity check of input file - bail out early if not a C/C++ header
+    if not args.inputHeaderFile.endswith(".h"):
+        parser.error(
+            "Invalid input file. Please specify a .h header file containing your filter declaration."
+        )
+
+    # Open input file for reading
+    with open(args.inputHeaderFile, mode="r") as source:
+        # Initialise dictionary of output values
+        config = dict()
+
+        # Initialise currently applicable C/C++ access specifier to unknown
+        accessLevel = None
+
+        # Initialise namespace string (may remain None if not present in input file)
+        namespaceIdentifier = None
+
+        # Value extractor utility
+        extractor = Extractor()
+
+        # Extract file name without extension
+        config["FilterClassFileName"] = extractor.extractFilterClassFileName(
+            args.inputHeaderFile
+        )
+
+        # Read input file one line at a time
+        while line := source.readline():
+            # Trim leading and trailing whitespace
+            line.strip()
+
+            if line.startswith("namespace"):
+                namespaceIdentifier = extractor.extractNamespace(line)
+
+            elif line.startswith("class"):
+                # Class declaration may be over several lines, collect them
+                bufferedLine = line
+                if not line.endswith("{"):
+                    # Keep reading - but not past EOF
+                    while line := source.readline():
+                        line.strip()
+                        # Break at start of member declarations
+                        if line.startswith("{"):
+                            break
+                        # Add more content to the buffered class declaration line
+                        else:
+                            bufferedLine = " ".join([bufferedLine, line])
+
+                # Extract the name of the output wrapper class
+                extractedValue = extractor.extractWrapperClassName(bufferedLine)
+                config = extractor.addToConfigIfNotNone(
+                    "WrapperClassName", extractedValue, config
+                )
+
+                # Extract FilterTypeDef (in combination with namespaceIdentifier)
+                extractedValue = extractor.extractFilterTypeDef(
+                    namespaceIdentifier, bufferedLine
+                )
+                config = extractor.addToConfigIfNotNone(
+                    "FilterTypeDef", extractedValue, config
+                )
+
+                # Extract number of template arguments if the class is templated
+                extractedValue = extractor.extractNumTemplateArgs(bufferedLine)
+                config = extractor.addToConfigIfNotNone(
+                    "NumTemplateArgs", extractedValue, config
+                )
+
+                # Try to infer if the component is a sink or a source/(source, sink) combination
+                extractedValue = extractor.extractComponentIsSink(bufferedLine)
+                config = extractor.addToConfigIfNotNone(
+                    "ComponentIsSink", extractedValue, config
+                )
+
+                # TODO: extract ComponentName if possible
+
+            # Check for an access specifier
+            elif line.startswith(ACCESS_SPECIFIERS):
+                # Update the access specifier access specifier
+                accessLevel = extractor.extractAccessSpecifier(line, ACCESS_SPECIFIERS)
+
+            # Only process public blocks
+            if accessLevel == "public":
+                # The functions we're interested in always return null
+                # TODO: this will also pick up a member variable of type void* that may be
+                #       typecast to something specific later (gross but possible)
+                if line.startswith("void"):
+                    # The function signature could be across more than one line
+                    bufferedLine = line
+                    if not line.endswith(";"):
+                        # Keep reading - but not past EOF
+                        while line := source.readline():
+                            line.strip()
+                            # Break at end of function signature
+                            if line.endswith(";"):
+                                break
+                            # Add more content to the buffered function signature line
+                            else:
+                                bufferedLine = " ".join([bufferedLine, line])
+
+                    # TODO: extract InputTypeFunc entry
+
+            # TODO: unclear how to extract RATGetSupport, RATSetSupport, ForwardInputUserIDs
+            # TODO: unclear how to decide what should be captured as a Property (and how to detect it)
+
+    # Sanity check: dictionary contents need to meet a few minimum requirements
+    minimumRequirementsMet = (
+        "WrapperClassName" in config
+        and config["WrapperClassName"] is not None
+        and "FilterClassFileName" in config
+        and config["FilterClassFileName"] is not None
+        and "FilterTypeDef" in config
+        and config["FilterTypeDef"] is not None
+    )
+    if not minimumRequirementsMet:
+        # Not enough information, can't proceed
+        print(
+            "Error processing header file: couldn't extract one of WrapperClassName, FilterClassFileName, or FilterTypeDef.\
+             Are you sure your header file defines an ITK / OTB filter?",
+            file=stderr,
+        )
+        exit(1)
+
+    # Author, Year and FileDate come out of the environment
+    config["Author"] = SCRIPT_NAME
+    config["Year"] = extractor.extractYear()
+    config["FileDate"] = extractor.extractFileDate()
+
+    # write results to config file
+    with open(args.outputConfigFile, mode="w") as destination:
+        # Config entry line builder
+        distiller = Distiller()
+
+        # Mandatory minimum entries
+        destination.writelines([distiller.distilInt("Year", config["Year"])])
+        destination.writelines(
+            [distiller.distilString("WrapperClassName", config["WrapperClassName"])]
+        )
+        destination.writelines([distiller.distilString("FileDate", config["FileDate"])])
+        destination.writelines([distiller.distilString("Author", config["Author"])])
+        destination.writelines(
+            [
+                distiller.distilString(
+                    "FilterClassFileName", config["FilterClassFileName"]
+                )
+            ]
+        )
+        destination.writelines(
+            [distiller.distilString("FilterTypeDef", config["FilterTypeDef"])]
+        )
+
+        # Optional int fields
+        distiller.writeIntToFileIfNotNone("RATGetSupport", config, destination)
+        distiller.writeIntToFileIfNotNone("RATSetSupport", config, destination)
+        distiller.writeIntToFileIfNotNone("NumTemplateArgs", config, destination)
+        distiller.writeIntToFileIfNotNone("ComponentIsSink", config, destination)
+
+        # Optional string fields
+        distiller.writeStringToFileIfNotNone("ComponentName", config, destination)
+        distiller.writeStringToFileIfNotNone("ForwardInputUserIDs", config, destination)
+
+        # Optional list fields
+        distiller.writeListToFileIfNotNone("InputTypeFunc", config, destination)
+        distiller.writeListToFileIfNotNone("Property", config, destination)

--- a/utils/WrapperTemplates/makeWrapperFactory.py
+++ b/utils/WrapperTemplates/makeWrapperFactory.py
@@ -8,182 +8,133 @@ import re
 import errno
 
 
-
 # ===============================================================================
-if __name__ == '__main__':
-    '''
+if __name__ == "__main__":
+    """
     open the files, do the copy, and do the main
     workflow here, then we'll break out to do some things
     more special
-    '''
+    """
     if len(sys.argv) < 11:
-        print ("Usage: $ %s makeWrapperFactory --cl_name <WrapperClassName> --alias <compAlias> --isSink <true | false> --author <author> --year <year> --date <date>")
+        print(
+            "Usage: $ %s makeWrapperFactory --cl_name <WrapperClassName> --alias <compAlias> --isSink <true | false> --author <author> --year <year> --date <date>"
+        )
         sys.exit()
 
     pdict = {}
 
     for i in range(1, len(sys.argv)):
-        print ("processing '%s' ..." % sys.argv[i])
+        print("processing '%s' ..." % sys.argv[i])
 
         if sys.argv[i] == "--cl_name":
-            pdict['cl_name'] = sys.argv[i+1]
-            pdict['cl_name_lower'] = pdict['cl_name'].lower()
-            pdict['cl_name_upper'] = pdict['cl_name'].upper()
+            pdict["cl_name"] = sys.argv[i + 1]
+            pdict["cl_name_lower"] = pdict["cl_name"].lower()
+            pdict["cl_name_upper"] = pdict["cl_name"].upper()
 
-            pdict['fac_name'] = sys.argv[i+1] + 'Factory'
+            pdict["fac_name"] = sys.argv[i + 1] + "Factory"
         elif sys.argv[i] == "--isSink":
-            if sys.argv[i+1] == "true" or sys.argv[i+1] == "false":
-                pdict['isSink'] = sys.argv[i+1]
+            if sys.argv[i + 1] == "true" or sys.argv[i + 1] == "false":
+                pdict["isSink"] = sys.argv[i + 1]
             else:
-                pdict['isSink'] = "false"
+                pdict["isSink"] = "false"
         elif sys.argv[i] == "--author":
-            pdict['author'] = sys.argv[i+1]
+            pdict["author"] = sys.argv[i + 1]
         elif sys.argv[i] == "--year":
-            pdict['year'] = sys.argv[i+1]
+            pdict["year"] = sys.argv[i + 1]
         elif sys.argv[i] == "--date":
-            pdict['date'] = sys.argv[i+1]
+            pdict["date"] = sys.argv[i + 1]
         elif sys.argv[i] == "--alias":
-            pdict['alias'] == sys.argv[i+1]
+            pdict["alias"] == sys.argv[i + 1]
 
     # test - debug
-    #for key in pdict:
+    # for key in pdict:
     #    print "%s = %s" % (key, pdict[key])
 
     searchDict = {}
-    searchDict['fac_name'] = "/*$<WrapperFactoryName>$*/"
-    searchDict['cl_name'] = "/*$<WrapperClassName>$*/"
-    searchDict['cl_name_lower'] = "/*$<WrapperClassNameLower>$*/"
-    searchDict['cl_name_upper'] = "/*$<WrapperClassNameUpper>$*/"
-    searchDict['fac_name'] = "/*$<WrapperFactoryName>$*/"
-    searchDict['alias']  = "/*$<ComponentAlias>$*/"
-    searchDict['author'] = "/*$<Author>$*/"
-    searchDict['isSink'] = "/*$<ProcessIsSink>$*/"
-    searchDict['year'] = "/*$<Year>$*/"
-    searchDict['date'] = "/*$<FileDate>$*/"
+    searchDict["fac_name"] = "/*$<WrapperFactoryName>$*/"
+    searchDict["cl_name"] = "/*$<WrapperClassName>$*/"
+    searchDict["cl_name_lower"] = "/*$<WrapperClassNameLower>$*/"
+    searchDict["cl_name_upper"] = "/*$<WrapperClassNameUpper>$*/"
+    searchDict["fac_name"] = "/*$<WrapperFactoryName>$*/"
+    searchDict["alias"] = "/*$<ComponentAlias>$*/"
+    searchDict["author"] = "/*$<Author>$*/"
+    searchDict["isSink"] = "/*$<ProcessIsSink>$*/"
+    searchDict["year"] = "/*$<Year>$*/"
+    searchDict["date"] = "/*$<FileDate>$*/"
 
     # =======================================================
     # create new wrapper factory class files from template files
 
-    factoryClassName = pdict['fac_name']
+    factoryClassName = pdict["fac_name"]
 
     filepath = inspect.getfile(inspect.currentframe())
     path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
-    if os.sep == '/':
-        pos = path.rfind('/', 0)
-        pos = path.rfind('/', 0, pos)
+    if os.sep == "/":
+        pos = path.rfind("/", 0)
+        pos = path.rfind("/", 0, pos)
     else:
-        pos = path.rfind('\\', 0)
-        pos = path.rfind('\\', 0, pos)
+        pos = path.rfind("\\", 0)
+        pos = path.rfind("\\", 0, pos)
 
     homepath = path[0:pos]
 
-    print ("    >>> Component Alias=%s" % pdict['alias'])
+    print("    >>> Component Alias=%s" % pdict["alias"])
 
-    frameworkpath = os.path.join(homepath, 'modellingframework')
-    targetpath = os.path.join(frameworkpath, 'wrapper')
-    print ("    >>> lumass HOME=%s" % homepath)
-    print ("    >>> wrapper file path: %s" % targetpath)
+    frameworkpath = os.path.join(homepath, "modellingframework")
+    targetpath = os.path.join(frameworkpath, "wrapper")
+    print("    >>> lumass HOME=%s" % homepath)
+    print("    >>> wrapper file path: %s" % targetpath)
 
-    inCppPath = os.path.join(path, 'WrapperFactoryTemplate.cpp')
-    inHPath   = os.path.join(path, 'WrapperFactoryTemplate.h')
+    inCppPath = os.path.join(path, "WrapperFactoryTemplate.cpp")
+    inHPath = os.path.join(path, "WrapperFactoryTemplate.h")
 
-    print ("   >>> inCppPath=%s" % inCppPath)
-    print ("   >>> inHPath=%s" % inHPath)
+    print("   >>> inCppPath=%s" % inCppPath)
+    print("   >>> inHPath=%s" % inHPath)
 
     classNameCPP = "%s.cpp" % (factoryClassName)
     classNameH = "%s.h" % (factoryClassName)
     cppPath = os.path.join(targetpath, classNameCPP)
     hPath = os.path.join(targetpath, classNameH)
 
-    print ("   >>> cppPath=%s" % cppPath)
-    print ("   >>> hPath=%s" % hPath)
-
+    print("   >>> cppPath=%s" % cppPath)
+    print("   >>> hPath=%s" % hPath)
 
     shutil.copyfile(inHPath, hPath)
     shutil.copyfile(inCppPath, cppPath)
-
 
     # =======================================================
     # process header file
 
     # HEADER FILE
     hStr = None
-    with open(hPath, 'r') as hWrapper:
+    with open(hPath, "r") as hWrapper:
         hStr = hWrapper.read()
 
         for key in pdict:
             hStr = hStr.replace(searchDict[key], pdict[key])
 
         if hStr.find("/*$<") != -1:
-            print ("WARNING: There's likely one or more unreplaced wrapper keywords left in %s!" % (hPath))
+            print(
+                "WARNING: There's likely one or more unreplaced wrapper keywords left in %s!"
+                % (hPath)
+            )
 
-    with open(hPath, 'w') as hWrapper:
+    with open(hPath, "w") as hWrapper:
         hWrapper.write(hStr)
-
-
 
     # CPP file
     cppStr = None
-    with open(cppPath, 'r') as cppWrapper:
+    with open(cppPath, "r") as cppWrapper:
         cppStr = cppWrapper.read()
 
         for key in pdict:
             cppStr = cppStr.replace(searchDict[key], pdict[key])
 
         if cppStr.find("/*$<") != -1:
-            print ("WARNING: There's likely one or more unreplaced wrapper keywords left in %s!" % (cppPath))
+            print(
+                "WARNING: There's likely one or more unreplaced wrapper keywords left in %s!"
+                % (cppPath)
+            )
 
-
-    with open(cppPath, 'w') as cppWrapper:
+    with open(cppPath, "w") as cppWrapper:
         cppWrapper.write(cppStr)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/utils/WrapperTemplates/pythonutils/distiller.py
+++ b/utils/WrapperTemplates/pythonutils/distiller.py
@@ -57,7 +57,7 @@ class Distiller:
     def distilListEntry(self, key: str, value: str) -> str:
         # Assemble output line
         keyEntry = "".join([key, "_", str(self._listIndex)])
-        line = "".join([keyEntry, self._getWhitespace(keyEntry), value])
+        line = "".join([keyEntry, self._getWhitespace(keyEntry), value, "\n"])
 
         # Need to keep track of how many entries we're up to
         self._listIndex = self._listIndex + 1

--- a/utils/WrapperTemplates/pythonutils/distiller.py
+++ b/utils/WrapperTemplates/pythonutils/distiller.py
@@ -1,0 +1,65 @@
+from typing import Any, TextIO
+
+
+class Distiller:
+    # ---Constructor--- #
+    def __init__(self, padTo: int = 28) -> None:
+        self._padTo = padTo
+        self._listIndex = 0
+
+    # ---Internal utils--- #
+    def _getWhitespace(self, key: str) -> str:
+        # Calculate amount of padding in string
+        padding = self._padTo - len(key)
+        if padding <= 0:
+            padding = 1
+
+        # Turn padding into whitespace
+        whitespace = " ".replace(" ", " " * padding)
+
+        return whitespace
+
+    def _resetListIndex(self) -> None:
+        self._listIndex = 0
+
+    # ---File writing functions--- #
+    def writeIntToFileIfNotNone(
+        self, key: str, config: dict[str, Any], file: TextIO
+    ) -> None:
+        if key in config and config[key] is not None:
+            file.writelines([self.distilInt(key, config[key])])
+
+    def writeStringToFileIfNotNone(
+        self, key: str, config: dict[str, Any], file: TextIO
+    ) -> None:
+        if key in config and config[key] is not None:
+            file.writelines([self.distilString(key, config[key])])
+
+    def writeListToFileIfNotNone(
+        self, key: str, config: dict[str, Any], file: TextIO
+    ) -> None:
+        if key in config and config[key] is not None and len(config[key]) > 0:
+            self._resetListIndex()
+            for listEntry in config[key]:
+                file.writelines([self.distilListEntry(key, listEntry)])
+
+    # ---Key/Value formatting functions--- #
+    def distilInt(self, key: str, value: int) -> str:
+        line = "".join([key, self._getWhitespace(key), repr(value), "\n"])
+
+        return line
+
+    def distilString(self, key: str, value: str) -> str:
+        line = "".join([key, self._getWhitespace(key), value, "\n"])
+
+        return line
+
+    def distilListEntry(self, key: str, value: str) -> str:
+        # Assemble output line
+        keyEntry = "".join([key, "_", str(self._listIndex)])
+        line = "".join([keyEntry, self._getWhitespace(keyEntry), value])
+
+        # Need to keep track of how many entries we're up to
+        self._listIndex = self._listIndex + 1
+
+        return line

--- a/utils/WrapperTemplates/pythonutils/distiller.py
+++ b/utils/WrapperTemplates/pythonutils/distiller.py
@@ -2,6 +2,17 @@ from typing import Any, TextIO
 
 
 class Distiller:
+    """Provides general-purpose functions to write dictionary entries to a file
+
+    The class implements write functions for three generic types of values, namely
+    int, string and list of string. That set covers the types found in a wrapper
+    config file for LUMASS. They keys are expected to be strings.
+
+    Since many of the entries are optional within the config file, the class also
+    implements a convenience function for each type of entry that checks if the
+    value is missing or None before deciding whether to write anything to file.
+    """
+
     # ---Constructor--- #
     def __init__(self, padTo: int = 28) -> None:
         self._padTo = padTo

--- a/utils/WrapperTemplates/pythonutils/extractor.py
+++ b/utils/WrapperTemplates/pythonutils/extractor.py
@@ -153,17 +153,4 @@ class Extractor:
         # TODO: there may be a way to refine this
         return self._getClassName(line)
 
-    def extractComponentIsSink(self, line: str) -> str:
-        templateParams = self._getTemplateParameters(line)
-
-        # Return value is undefined if class is not templated
-        if not templateParams:
-            return None
-        # Only one template parameter - must be a sink
-        elif len(templateParams) == 1:
-            return 1
-        # Anything else - not a sink
-        else:
-            return 0
-
     # TODO: functions for Property, InputTypeFunc

--- a/utils/WrapperTemplates/pythonutils/extractor.py
+++ b/utils/WrapperTemplates/pythonutils/extractor.py
@@ -1,0 +1,169 @@
+from typing import Any
+
+import datetime
+import re
+
+
+class Extractor:
+    # ---Constructor--- #
+    def __init__(self) -> None:
+        self._classname = None
+        self._templateParams = None
+
+    # ---Internal utils--- #
+    def _getClassName(self, line: str) -> str:
+        # Sanity check
+        if not line:
+            return None
+
+        # Fill in cached value if there's none yet
+        if not self._classname:
+            # Extract the bit before the parent class
+            self._classname = line.split(":")[0]
+
+            # Class name will be the word at the end
+            self._classname.strip()
+            self._classname = self._classname.split()[-1]
+
+            # First letter should be upper case for further processing
+            self._classname = self._classname[0].upper() + self._classname[1:]
+
+        return self._classname
+
+    def _getTemplateParameters(self, line: str) -> list[str]:
+        # Sanity check - no bracket, no template parameters
+        if not line or not "<" in line:
+            return None
+
+        # Populate cached field if necessary
+        if not self._templateParams:
+            # Template parameters are a comma-separated list between brackets
+            self._templateParams = line.split("<")[-1].split(">")[0].split(",")
+            self._templateParams = [t.strip() for t in self._templateParams]
+
+        return self._templateParams
+
+    # ---Non-dictionary functions--- #
+    def extractAccessSpecifier(self, line, accessSpecifiers: list[str]) -> str:
+        # Pack up the list of words of interests in a regex
+        pattern = "|".join(accessSpecifiers)
+
+        # Extract and return the first match
+        accessLevel = re.match(pattern, line).group()
+
+        return accessLevel
+
+    def addToConfigIfNotNone(
+        self, key: str, value: Any, dictionary: dict[str, Any]
+    ) -> dict[str, Any]:
+        if value is not None:
+            dictionary[key] = value
+
+        return dictionary
+
+    # ---Dictionary functions--- #
+    def extractNamespace(self, line: str) -> str:
+        namespaceIdentifier = line.split()[1]
+        return namespaceIdentifier
+
+    def extractYear(self) -> int:
+        today = datetime.date.today()
+
+        return today.year
+
+    def extractWrapperClassName(self, line: str) -> str:
+        # Extract class name
+        classname = self._getClassName(line)
+
+        # Embed class name in wrapper name
+        if classname is not None:
+            return "NM{}Wrapper".format(classname)
+        else:
+            return None
+
+    def extractFileDate(self) -> str:
+        today = datetime.date.today()
+
+        return str(today)
+
+    def extractFilterClassFileName(self, filePath: str) -> str:
+        # Remove file extension
+        filterClassFileName = filePath.split(".")[-2]
+
+        # Remove folder in path if present
+        if "/" in filterClassFileName:
+            filterClassFileName = filterClassFileName.split("/")[-1]
+        elif "\\" in filterClassFileName:
+            filterClassFileName = filterClassFileName.split("\\")[-1]
+
+        # Return extracted value
+        return filterClassFileName
+
+    def extractFilterTypeDef(self, namespaceIdentifier: str, line: str) -> str:
+        # Bail out early if no class name is found
+        classname = self._getClassName(line)
+        if classname is None:
+            return None
+
+        # Prepend the namespace identifier if there is one
+        if namespaceIdentifier is not None:
+            classname = "::".join([namespaceIdentifier, classname])
+
+        # Extract the template type signature
+        templateParams = self._getTemplateParameters(line)
+
+        # Replace the template types with matching generic ones
+        # TODO: this is too tailored to image-to-image filters
+        #       need to be able to handle list lengths of more than 2
+        #       need to be able to handle non-image template types
+        if templateParams is not None and len(templateParams) == 2:
+            templateParams[0] = "InImgType"
+            if len(templateParams) > 1:
+                templateParams[1] = "OutImgType"
+
+            # Append the extracted template types and combine with classname
+            return "".join([classname, "<", ",".join(templateParams), ">"])
+
+        # Just need to return what we already have if there's nothing to add
+        else:
+            return classname
+
+    def extractRATGetSupport(self, line: str) -> str:
+        # TODO
+        return None
+
+    def extractRATSetSupport(self, line: str) -> str:
+        # TODO
+        return None
+
+    def extractForwardInputUserIDs(self, line: str) -> str:
+        # TODO
+        return None
+
+    def extractNumTemplateArgs(self, line: str) -> str:
+        templateParams = self._getTemplateParameters(line)
+
+        # Only return an number if the class is actually templated
+        if not templateParams:
+            return None
+        else:
+            return len(templateParams)
+
+    def extractComponentName(self, line: str) -> str:
+        # TODO
+        return None
+
+    def extractComponentIsSink(self, line: str) -> str:
+        templateParams = self._getTemplateParameters(line)
+
+        # Return value is undefined if class is not templated
+        if not templateParams:
+            return None
+        # Only one template parameter - must be a sink
+        elif len(templateParams) == 1:
+            return 1
+        # Anything else - not a sink
+        else:
+            return 0
+
+    # TODO: functions for Property, InputTypeFunc

--- a/utils/WrapperTemplates/pythonutils/extractor.py
+++ b/utils/WrapperTemplates/pythonutils/extractor.py
@@ -5,6 +5,23 @@ import re
 
 
 class Extractor:
+    """Functions to parse config-specific entries out of lines from a C++ header file for an ITK/OTB filer
+
+    The class provides a bunch of functions to parse and buffer information for specific entries that will
+    need to go into the output wrapper config later. It covers the keys given in makeNMItkProcessObjWrapper.py
+    with - currently - the exception of the Property entries.
+
+    Since many of the entries are optional within the config file, the class implements convenience functions
+    for adding atomic values and lists to the internal config buffer as well. They check if there's anything
+    to add at all before modifying the buffer, leaving it along if there's no new information.
+
+    An additional small set of utility functions handles information that will not be captured in the buffered
+    config, or consists of partial information for it. We're only interested in the section of the C++ header
+    that's declared as public, for example, and we need a way of finding that section. Or for an unrelated one,
+    extracting a function name has multiple uses but we usually embed it in a longer string when formatting
+    the output.
+    """
+
     # ---Constructor--- #
     def __init__(self) -> None:
         self._classname = None

--- a/utils/WrapperTemplates/pythonutils/extractor.py
+++ b/utils/WrapperTemplates/pythonutils/extractor.py
@@ -150,8 +150,8 @@ class Extractor:
             return len(templateParams)
 
     def extractComponentName(self, line: str) -> str:
-        # TODO
-        return None
+        # TODO: there may be a way to refine this
+        return self._getClassName(line)
 
     def extractComponentIsSink(self, line: str) -> str:
         templateParams = self._getTemplateParameters(line)


### PR DESCRIPTION
Added three new Python scripts to utils/WrapperTemplates:
- makeWrapperConfigFile.py (the main script)
- pythonutils/extractor.py (utilities class for parsing information out of the .h file)
- pythonutils/distiller.py (utilities class for writing information to the .lwp file)

They implement a partial but functional proof of concept for turning C++ headers for ITK/OTB filters into wrapper configuration files for LUMASS. You'll find a more detailed writeup of what was and wasn't done in the attached Word document. I included some thoughts about where to potentially go from here as well. (I hope! Let me know if the upload didn't work and I'll get it to you through another channel.)

[ITKOTB_automated_filter_wrapping.docx] (https://github.com/manaakiwhenua/LUMASS/files/15055634/ITKOTB_automated_filter_wrapping.docx)

Note: It says that 5 files were changed but only 4 of those are actually meaningful. The changes in makeWrapperFactory.py are purely related to (auto)formatting that my IDE does and weren't strictly speaking meant to be committed at all. There are no functional changes within that script.
